### PR TITLE
Fixed check for java executable in linux startup.

### DIFF
--- a/resources/Scripts/IBController.sh
+++ b/resources/Scripts/IBController.sh
@@ -126,8 +126,8 @@ if [[ ! -e "$TWS_PATH/$TWS_VERSION/tws.vmoptions" ]]; then
 fi
 
 if [[ -n $JAVA_PATH ]]; then
-	if [[ ! -e "$JAVA_PATH/java.exe" ]]; then 
-		echo $JAVA_PATH/java.exe does not exist
+	if [[ ! -e "$JAVA_PATH/java" ]]; then 
+		echo $JAVA_PATH/java does not exist
 		exit $E_NO_JAVA
 	fi
 fi


### PR DESCRIPTION
When the java path is supplied via command line parameter, don't look for "java.exe" under linux.