### PR TITLE
export APP var in IBControllerGatewayStart-OSX.sh

### DIFF
--- a/resources/IBControllerGatewayStart-OSX.sh
+++ b/resources/IBControllerGatewayStart-OSX.sh
@@ -132,7 +132,7 @@ JAVA_PATH=
 #   End of Notes:
 #==============================================================================
 
-APP=GATEWAY
+export APP=GATEWAY
 
 export TWS_MAJOR_VRSN
 export IBC_INI


### PR DESCRIPTION
I needed to export APP var in order to correctly launch IB Gateway, rather than version 952 of TWS