### PR TITLE
forwarding signals to the java child process in bash start scripts

### DIFF
--- a/resources/IBControllerGatewayStart-OSX.sh
+++ b/resources/IBControllerGatewayStart-OSX.sh
@@ -151,7 +151,7 @@ export JAVA_PATH
 export APP
 
 if [[ "$1" == "-inline" ]]; then
-    "${IBC_PATH}/Scripts/DisplayBannerAndLaunch.sh"
+    exec "${IBC_PATH}/Scripts/DisplayBannerAndLaunch.sh"
 else
     osascript -e 'tell app "Terminal"
         do script "${IBC_PATH}/Scripts/DisplayBannerAndLaunch.sh"

--- a/resources/IBControllerGatewayStart.sh
+++ b/resources/IBControllerGatewayStart.sh
@@ -162,7 +162,7 @@ if [[ "$hide" = "YES" || "$hide" = "TRUE" ]]; then
 fi
 
 if [[ "$1" == "-inline" ]]; then
-    "${IBC_PATH}/Scripts/DisplayBannerAndLaunch.sh"
+    exec "${IBC_PATH}/Scripts/DisplayBannerAndLaunch.sh"
 else
     title="IBController ($APP $TWS_MAJOR_VRSN)"
     xterm $iconic -T "$title" -e "${IBC_PATH}/Scripts/DisplayBannerAndLaunch.sh" &

--- a/resources/IBControllerStart-OSX.sh
+++ b/resources/IBControllerStart-OSX.sh
@@ -137,10 +137,9 @@ export JAVA_PATH
 export APP
 
 if [[ "$1" == "-inline" ]]; then
-    "${IBC_PATH}/Scripts/DisplayBannerAndLaunch.sh"
+    exec "${IBC_PATH}/Scripts/DisplayBannerAndLaunch.sh"
 else
     osascript -e 'tell app "Terminal"
         do script "${IBC_PATH}/Scripts/DisplayBannerAndLaunch.sh"
     end tell'
 fi
-

--- a/resources/IBControllerStart.sh
+++ b/resources/IBControllerStart.sh
@@ -148,8 +148,8 @@ if [[ "$hide" = "YES" || "$hide" = "TRUE" ]]; then
 fi
 
 if [[ "$1" == "-inline" ]]; then
-    "${IBC_PATH}/Scripts/DisplayBannerAndLaunch.sh"
+  exec "${IBC_PATH}/Scripts/DisplayBannerAndLaunch.sh"
 else
-    title="IBController ($APP $TWS_MAJOR_VRSN)"
-    xterm $iconic -T "$title" -e "${IBC_PATH}/Scripts/DisplayBannerAndLaunch.sh" &
+  title="IBController ($APP $TWS_MAJOR_VRSN)"
+  xterm $iconic -T "$title" -e "${IBC_PATH}/Scripts/DisplayBannerAndLaunch.sh" &
 fi

--- a/resources/Scripts/DisplayBannerAndLaunch.sh
+++ b/resources/Scripts/DisplayBannerAndLaunch.sh
@@ -54,12 +54,21 @@ fi
 echo -e ${normal}
 
 export IBC_VRSN
+
+# forward signals (see https://veithen.github.io/2014/11/16/sigterm-propagation.html)
+trap 'kill -TERM $PID' TERM INT
+
 "${IBC_PATH}/Scripts/IBController.sh" "${TWS_MAJOR_VRSN}" ${gw_flag} \
      "--tws-path=${TWS_PATH}" "--tws-settings-path=${TWS_CONFIG_PATH}" \
 	 "--ibc-path=${IBC_PATH}" "--ibc-ini=${IBC_INI}" \
      "--user=${TWSUSERID}" "--pw=${TWSPASSWORD}" "--fix-user=${FIXUSERID}" "--fix-pw=${FIXPASSWORD}" \
      "--java-path=${JAVA_PATH}" "--mode=${TRADING_MODE}" \
-     >> "${log_file}" 2>&1
+     >> "${log_file}" 2>&1 &
+
+PID=$!
+wait $PID
+trap - TERM INT
+wait $PID
 
 if [ "$?" != "0" ]; then
 	echo -e ${light_red}

--- a/resources/Scripts/IBController.sh
+++ b/resources/Scripts/IBController.sh
@@ -411,15 +411,23 @@ JAVA_TOOL_OPTIONS=
 
 pushd "$tws_path" > /dev/null
 
+# forward signals (see https://veithen.github.io/2014/11/16/sigterm-propagation.html)
+trap 'kill -TERM $PID' TERM INT
+
 if [[ -n $got_fix_credentials && -n $got_api_credentials ]]; then
-	"$java_path/java" -cp "$ibc_classpath" $java_vm_options $entry_point "$ibc_ini" "$fix_user_id" "$fix_password" "$ib_user_id" "$ib_password" ${mode}
+	"$java_path/java" -cp "$ibc_classpath" $java_vm_options $entry_point "$ibc_ini" "$fix_user_id" "$fix_password" "$ib_user_id" "$ib_password" ${mode} &
 elif  [[ -n $got_fix_credentials ]]; then
-	"$java_path/java" -cp "$ibc_classpath" $java_vm_options $entry_point "$ibc_ini" "$fix_user_id" "$fix_password" ${mode}
+	"$java_path/java" -cp "$ibc_classpath" $java_vm_options $entry_point "$ibc_ini" "$fix_user_id" "$fix_password" ${mode} &
 elif [[ -n $got_api_credentials ]]; then
-	"$java_path/java" -cp "$ibc_classpath" $java_vm_options $entry_point "$ibc_ini" "$ib_user_id" "$ib_password" ${mode}
+	"$java_path/java" -cp "$ibc_classpath" $java_vm_options $entry_point "$ibc_ini" "$ib_user_id" "$ib_password" ${mode} &
 else
-	"$java_path/java" -cp "$ibc_classpath" $java_vm_options $entry_point "$ibc_ini" ${mode}
+	"$java_path/java" -cp "$ibc_classpath" $java_vm_options $entry_point "$ibc_ini" ${mode} &
 fi
+
+PID=$!
+wait $PID
+trap - TERM INT
+wait $PID
 
 exit_code=$?
 echo "$program finished"


### PR DESCRIPTION
This enables controlling systems such as supervisord and docker to stop the running java application (TWS or IBG) instead of just stopping the shell scripts which started the java application.

For a detailed explanation, see https://veithen.github.io/2014/11/16/sigterm-propagation.html

This change only affects the application running under Linux. I tested it under Linux with TWS version 963 (but the TWS version shouldn't make any difference for this change).