### PR TITLE
fix Login handling for TWS 978.1d

### DIFF
--- a/src/ibcontroller/AbstractLoginHandler.java
+++ b/src/ibcontroller/AbstractLoginHandler.java
@@ -20,6 +20,8 @@ package ibcontroller;
 
 import java.awt.Window;
 import java.awt.event.WindowEvent;
+
+import javax.swing.JButton;
 import javax.swing.JComboBox;
 import javax.swing.JFrame;
 
@@ -52,18 +54,21 @@ public abstract class AbstractLoginHandler implements WindowHandler {
     
     @Override
     public abstract boolean recogniseWindow(Window window);
+
     
     private void doLogin(final Window window) throws IBControllerException {
-        if (SwingUtils.findButton(window, "Login") == null) throw new IBControllerException("Login button");
+        if (findLoginButton(window) == null) throw new IBControllerException("Login button");
 
         GuiDeferredExecutor.instance().execute(new Runnable() {
             @Override
             public void run() {
-                SwingUtils.clickButton(window, "Login");
+                SwingUtils.clickButton(findLoginButton(window));
             }
         });
     }
-    
+
+    protected abstract JButton findLoginButton(Window window);
+
     protected abstract boolean initialise(final Window window, int eventID) throws IBControllerException;
     
     protected abstract boolean preLogin(final Window window, int eventID) throws IBControllerException;

--- a/src/ibcontroller/GatewayLoginFrameHandler.java
+++ b/src/ibcontroller/GatewayLoginFrameHandler.java
@@ -19,17 +19,24 @@
 package ibcontroller;
 
 import java.awt.Window;
+
+import javax.swing.JButton;
 import javax.swing.JFrame;
 import javax.swing.JRadioButton;
 
 final class GatewayLoginFrameHandler extends AbstractLoginHandler {
-    
+
     @Override
     public boolean recogniseWindow(Window window) {
         if (! (window instanceof JFrame)) return false;
 
         return (SwingUtils.titleContains(window, "IB Gateway") &&
-               (SwingUtils.findButton(window, "Login") != null));
+               (findLoginButton(window) != null));
+    }
+
+    @Override
+    protected JButton findLoginButton(Window window) {
+    	return SwingUtils.findButton(window, "Login");
     }
 
     @Override

--- a/src/ibcontroller/LoginFrameHandler.java
+++ b/src/ibcontroller/LoginFrameHandler.java
@@ -19,21 +19,30 @@
 package ibcontroller;
 
 import java.awt.Window;
+
+import javax.swing.JButton;
 import javax.swing.JFrame;
 
 final class LoginFrameHandler extends AbstractLoginHandler {
 
-    @Override
+	@Override
     public boolean recogniseWindow(Window window) {
         if (! (window instanceof JFrame)) return false;
 
-        // we check for the presence of the Login button because 
-        // TWS displays a different (information-only) dialog, also 
+        // we check for the presence of the Login button because
+        // TWS displays a different (information-only) dialog, also
         // entitled Login, when it's trying to reconnect
-        return ((SwingUtils.titleEquals(window, "New Login") ||
-                SwingUtils.titleEquals(window, "Login")) &&
-                SwingUtils.findButton(window, "Login") != null);
+        return ((SwingUtils.titleEquals(window, "New Login") || SwingUtils.titleEquals(window, "Login"))
+        		&& findLoginButton(window)!=null);
     }
+
+	@Override
+	protected JButton findLoginButton(Window window) {
+		JButton result = SwingUtils.findButton(window, "Login");
+		if (result==null)
+			result=SwingUtils.findButton(window, "Log In");
+		return result;
+	}
 
     @Override
     protected final boolean initialise(final Window window, int eventID) throws IBControllerException {

--- a/src/ibcontroller/SwingUtils.java
+++ b/src/ibcontroller/SwingUtils.java
@@ -57,16 +57,20 @@ class SwingUtils {
         final JButton button = findButton(window, buttonText);
         if (button == null) return false;
 
-        if (! button.isEnabled()) {
+        return clickButton(button);
+    }
+
+	 static boolean clickButton(final JButton button) {
+		if (! button.isEnabled()) {
             button.setEnabled(true);
-            Utils.logToConsole("Button was disabled, has been enabled: " + buttonText);
+            Utils.logToConsole("Button was disabled, has been enabled: " + button.getText());
         }
 
-        Utils.logToConsole("Click button: " + buttonText);
+        Utils.logToConsole("Click button: " + button.getText());
         button.doClick();
-        if (! button.isEnabled()) Utils.logToConsole("Button now disabled: " + buttonText);
+        if (! button.isEnabled()) Utils.logToConsole("Button now disabled: " + button.getText());
         return true;
-    }
+	}
 
     /**
      * Traverses a container hierarchy and returns the button with


### PR DESCRIPTION
In TWS 978.1d the `Login` button on the login screen was renamed to `Log In`. This adds support for the new name.